### PR TITLE
Add missing properties and methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ mock_db = MockFirestore()
 mock_db.collection('users')
 mock_db.collection('users').get()
 mock_db.collection('users').list_documents()
+mock_db.collection('users').stream()
 
 # Documents
 mock_db.collection('users').document()

--- a/README.md
+++ b/README.md
@@ -56,6 +56,9 @@ mock_db.collection('users').document('alovelace').update({
 mock_db.collection('users').document('alovelace').collection('friends')
 mock_db.collection('users').document('alovelace').delete()
 
+mock_db.collection('users').add({'first': 'Ada', 'last': 'Lovelace'},
+                                'alovelace')
+
 # Querying
 mock_db.collection('users').document('alovelace').order_by('born').get()
 mock_db.collection('users').document('alovelace').order_by('born', direction='DESCENDING').get()

--- a/mockfirestore/main.py
+++ b/mockfirestore/main.py
@@ -30,9 +30,11 @@ class DocumentSnapshot:
 
 
 class DocumentReference:
-    def __init__(self, data: Store, path: List[str]) -> None:
+    def __init__(self, data: Store, path: List[str],
+                 parent: 'CollectionReference') -> None:
         self._data = data
         self._path = path
+        self.parent = parent
 
     @property
     def id(self):
@@ -58,7 +60,7 @@ class DocumentReference:
         new_path = self._path + [name]
         if name not in document:
             set_by_path(self._data, new_path, {})
-        return CollectionReference(self._data, new_path)
+        return CollectionReference(self._data, new_path, parent=self)
 
 
 class Query:
@@ -141,9 +143,11 @@ class Query:
 
 
 class CollectionReference:
-    def __init__(self, data: Store, path: List[str]) -> None:
+    def __init__(self, data: Store, path: List[str],
+                 parent: Optional[DocumentReference] = None) -> None:
         self._data = data
         self._path = path
+        self.parent = parent
 
     def document(self, name: Optional[str] = None) -> DocumentReference:
         collection = get_by_path(self._data, self._path)
@@ -152,7 +156,7 @@ class CollectionReference:
         new_path = self._path + [name]
         if name not in collection:
             set_by_path(self._data, new_path, {})
-        return DocumentReference(self._data, new_path)
+        return DocumentReference(self._data, new_path, parent=self)
 
     def get(self) -> Iterable[DocumentSnapshot]:
         warnings.warn('Collection.get is deprecated, please use Collection.stream',

--- a/mockfirestore/main.py
+++ b/mockfirestore/main.py
@@ -153,8 +153,10 @@ class CollectionReference:
             set_by_path(self._data, new_path, {})
         return DocumentReference(self._data, new_path)
 
-    def get(self) -> Iterator[DocumentSnapshot]:
-        return Query(self).get()
+    def get(self) -> Iterable[DocumentSnapshot]:
+        warnings.warn('Collection.get is deprecated, please use Collection.stream',
+                      category=DeprecationWarning)
+        return self.stream()
 
     def where(self, field: str, op: str, value: Any) -> Query:
         query = Query(self, field_filters=[(field, op, value)])
@@ -175,7 +177,7 @@ class CollectionReference:
         return docs
 
     def stream(self, transaction=None) -> Iterable[DocumentSnapshot]:
-        for key in get_by_path(self._data, self._path):
+        for key in sorted(get_by_path(self._data, self._path)):
             doc_snapshot = self.document(key).get()
             yield doc_snapshot
 

--- a/mockfirestore/main.py
+++ b/mockfirestore/main.py
@@ -4,7 +4,8 @@ import string
 from collections import OrderedDict
 from functools import reduce
 from itertools import islice
-from typing import Dict, Any, List, Tuple, TypeVar, Sequence, Callable, Optional, Iterator
+from typing import (Dict, Any, List, Tuple, TypeVar, Sequence, Callable, Optional,
+                    Iterator, Iterable)
 
 T = TypeVar('T')
 KeyValuePair = Tuple[str, Dict[str, Any]]
@@ -128,6 +129,11 @@ class CollectionReference:
         for key in get_by_path(self._data, self._path):
             docs.append(self.document(key))
         return docs
+
+    def stream(self, transaction=None) -> Iterable[DocumentSnapshot]:
+        for key in get_by_path(self._data, self._path):
+            doc_snapshot = self.document(key).get()
+            yield doc_snapshot
 
 
 class MockFirestore:

--- a/mockfirestore/main.py
+++ b/mockfirestore/main.py
@@ -6,6 +6,7 @@ from functools import reduce
 from itertools import islice
 from typing import (Dict, Any, List, Tuple, TypeVar, Sequence, Callable, Optional,
                     Iterator, Iterable)
+import warnings
 
 T = TypeVar('T')
 KeyValuePair = Tuple[str, Dict[str, Any]]
@@ -99,10 +100,15 @@ class Query:
 
         return data
 
-    def get(self) -> Iterator[DocumentSnapshot]:
+    def stream(self) -> Iterator[DocumentSnapshot]:
         doc_refs = self.parent.list_documents()
         return (DocumentSnapshot(doc_ref, doc) for doc_ref, doc
                 in zip(doc_refs, self._data.values()))
+
+    def get(self) -> Iterator[DocumentSnapshot]:
+        warnings.warn('Query.get is deprecated, please use Query.stream',
+                      category=DeprecationWarning)
+        return self.stream()
 
     def _add_field_filter(self, field: str, op: str, value: Any):
         compare = self._compare_func(op)

--- a/mockfirestore/main.py
+++ b/mockfirestore/main.py
@@ -15,8 +15,9 @@ Store = Dict[str, Collection]
 
 
 class DocumentSnapshot:
-    def __init__(self, doc: Document) -> None:
-        self._doc = doc
+    def __init__(self, reference: 'DocumentReference', data: Document) -> None:
+        self.reference = reference
+        self._doc = data
 
     @property
     def exists(self) -> bool:
@@ -36,7 +37,7 @@ class DocumentReference:
         return self._path[-1]
 
     def get(self) -> DocumentSnapshot:
-        return DocumentSnapshot(get_by_path(self._data, self._path))
+        return DocumentSnapshot(self, get_by_path(self._data, self._path))
 
     def delete(self):
         delete_by_path(self._data, self._path)
@@ -99,7 +100,9 @@ class Query:
         return data
 
     def get(self) -> Iterator[DocumentSnapshot]:
-        return (DocumentSnapshot(doc) for doc in self._data.values())
+        doc_refs = self.parent.list_documents()
+        return (DocumentSnapshot(doc_ref, doc) for doc_ref, doc
+                in zip(doc_refs, self._data.values()))
 
     def _add_field_filter(self, field: str, op: str, value: Any):
         compare = self._compare_func(op)

--- a/mockfirestore/main.py
+++ b/mockfirestore/main.py
@@ -136,8 +136,8 @@ class Query:
         doc_snapshots = self.parent.stream()
 
         for field, compare, value in self._field_filters:
-            doc_snapshots = (doc_snapshot for doc_snapshot in doc_snapshots
-                             if compare(doc_snapshot.to_dict()[field], value))
+            doc_snapshots = [doc_snapshot for doc_snapshot in doc_snapshots
+                             if compare(doc_snapshot.to_dict()[field], value)]
 
         if self.orders:
             for key, direction in self.orders:

--- a/mockfirestore/main.py
+++ b/mockfirestore/main.py
@@ -2,6 +2,7 @@ import operator
 import random
 import string
 from collections import OrderedDict
+from copy import deepcopy
 from functools import reduce
 from itertools import islice
 from typing import (Dict, Any, List, Tuple, TypeVar, Sequence, Callable, Optional,
@@ -18,7 +19,7 @@ Store = Dict[str, Collection]
 class DocumentSnapshot:
     def __init__(self, reference: 'DocumentReference', data: Document) -> None:
         self.reference = reference
-        self._doc = data
+        self._doc = deepcopy(data)
 
     @property
     def exists(self) -> bool:

--- a/tests/test_collection_reference.py
+++ b/tests/test_collection_reference.py
@@ -1,6 +1,6 @@
 from unittest import TestCase
 
-from mockfirestore import MockFirestore, DocumentReference
+from mockfirestore import MockFirestore, DocumentReference, DocumentSnapshot
 
 
 class TestCollectionReference(TestCase):
@@ -158,3 +158,15 @@ class TestCollectionReference(TestCase):
         self.assertEqual(3, len(doc_refs))
         for doc_ref in doc_refs:
             self.assertIsInstance(doc_ref, DocumentReference)
+
+    def test_collection_stream(self):
+        fs = MockFirestore()
+        fs._data = {'foo': {
+            'first': {'order': 2},
+            'second': {'order': 1},
+            'third': {'order': 3}
+        }}
+        doc_snapshots = list(fs.collection('foo').stream())
+        self.assertEqual(3, len(doc_snapshots))
+        for doc_snapshot in doc_snapshots:
+            self.assertIsInstance(doc_snapshot, DocumentSnapshot)

--- a/tests/test_collection_reference.py
+++ b/tests/test_collection_reference.py
@@ -170,3 +170,16 @@ class TestCollectionReference(TestCase):
         self.assertEqual(3, len(doc_snapshots))
         for doc_snapshot in doc_snapshots:
             self.assertIsInstance(doc_snapshot, DocumentSnapshot)
+
+    def test_collection_parent(self):
+        fs = MockFirestore()
+        fs._data = {'foo': {
+            'first': {'order': 2},
+            'second': {'order': 1},
+            'third': {'order': 3}
+        }}
+        doc_snapshots = fs.collection('foo').stream()
+        for doc_snapshot in doc_snapshots:
+            doc_reference = doc_snapshot.reference
+            subcollection = doc_reference.collection('order')
+            self.assertIs(subcollection.parent, doc_reference)

--- a/tests/test_collection_reference.py
+++ b/tests/test_collection_reference.py
@@ -10,14 +10,14 @@ class TestCollectionReference(TestCase):
             'first': {'id': 1},
             'second': {'id': 2}
         }}
-        docs = list(fs.collection('foo').get())
+        docs = list(fs.collection('foo').stream())
 
         self.assertEqual({'id': 1}, docs[0].to_dict())
         self.assertEqual({'id': 2}, docs[1].to_dict())
 
     def test_collection_get_collectionDoesNotExist(self):
         fs = MockFirestore()
-        docs = fs.collection('foo').get()
+        docs = fs.collection('foo').stream()
         self.assertEqual([], list(docs))
 
     def test_collection_get_nestedCollection(self):
@@ -30,7 +30,7 @@ class TestCollectionReference(TestCase):
                 }
             }
         }}
-        docs = list(fs.collection('foo').document('first').collection('bar').get())
+        docs = list(fs.collection('foo').document('first').collection('bar').stream())
         self.assertEqual({'id': 1.1}, docs[0].to_dict())
 
     def test_collection_get_nestedCollection_collectionDoesNotExist(self):
@@ -38,7 +38,7 @@ class TestCollectionReference(TestCase):
         fs._data = {'foo': {
             'first': {'id': 1}
         }}
-        docs = list(fs.collection('foo').document('first').collection('bar').get())
+        docs = list(fs.collection('foo').document('first').collection('bar').stream())
         self.assertEqual([], docs)
 
     def test_collection_get_ordersByAscendingDocumentId_byDefault(self):
@@ -47,7 +47,7 @@ class TestCollectionReference(TestCase):
             'beta': {'id': 1},
             'alpha': {'id': 2}
         }}
-        docs = list(fs.collection('foo').get())
+        docs = list(fs.collection('foo').stream())
         self.assertEqual({'id': 2}, docs[0].to_dict())
 
     def test_collection_whereEquals(self):
@@ -57,7 +57,7 @@ class TestCollectionReference(TestCase):
             'second': {'valid': False}
         }}
 
-        docs = list(fs.collection('foo').where('valid', '==', True).get())
+        docs = list(fs.collection('foo').where('valid', '==', True).stream())
         self.assertEqual({'valid': True}, docs[0].to_dict())
 
     def test_collection_whereLessThan(self):
@@ -67,7 +67,7 @@ class TestCollectionReference(TestCase):
             'second': {'count': 5}
         }}
 
-        docs = list(fs.collection('foo').where('count', '<', 5).get())
+        docs = list(fs.collection('foo').where('count', '<', 5).stream())
         self.assertEqual({'count': 1}, docs[0].to_dict())
 
     def test_collection_whereLessThanOrEqual(self):
@@ -77,7 +77,7 @@ class TestCollectionReference(TestCase):
             'second': {'count': 5}
         }}
 
-        docs = list(fs.collection('foo').where('count', '<=', 5).get())
+        docs = list(fs.collection('foo').where('count', '<=', 5).stream())
         self.assertEqual({'count': 1}, docs[0].to_dict())
         self.assertEqual({'count': 5}, docs[1].to_dict())
 
@@ -88,7 +88,7 @@ class TestCollectionReference(TestCase):
             'second': {'count': 5}
         }}
 
-        docs = list(fs.collection('foo').where('count', '>', 1).get())
+        docs = list(fs.collection('foo').where('count', '>', 1).stream())
         self.assertEqual({'count': 5}, docs[0].to_dict())
 
     def test_collection_whereGreaterThanOrEqual(self):
@@ -98,7 +98,7 @@ class TestCollectionReference(TestCase):
             'second': {'count': 5}
         }}
 
-        docs = list(fs.collection('foo').where('count', '>=', 1).get())
+        docs = list(fs.collection('foo').where('count', '>=', 1).stream())
         self.assertEqual({'count': 1}, docs[0].to_dict())
         self.assertEqual({'count': 5}, docs[1].to_dict())
 
@@ -109,7 +109,7 @@ class TestCollectionReference(TestCase):
             'second': {'order': 1}
         }}
 
-        docs = list(fs.collection('foo').order_by('order').get())
+        docs = list(fs.collection('foo').order_by('order').stream())
         self.assertEqual({'order': 1}, docs[0].to_dict())
         self.assertEqual({'order': 2}, docs[1].to_dict())
 
@@ -121,7 +121,7 @@ class TestCollectionReference(TestCase):
             'third': {'order': 1}
         }}
 
-        docs = list(fs.collection('foo').order_by('order', direction="DESCENDING").get())
+        docs = list(fs.collection('foo').order_by('order', direction="DESCENDING").stream())
         self.assertEqual({'order': 3}, docs[0].to_dict())
         self.assertEqual({'order': 2}, docs[1].to_dict())
         self.assertEqual({'order': 1}, docs[2].to_dict())
@@ -132,7 +132,7 @@ class TestCollectionReference(TestCase):
             'first': {'id': 1},
             'second': {'id': 2}
         }}
-        docs = list(fs.collection('foo').limit(1).get())
+        docs = list(fs.collection('foo').limit(1).stream())
         self.assertEqual({'id': 1}, docs[0].to_dict())
         self.assertEqual(1, len(docs))
 
@@ -143,7 +143,7 @@ class TestCollectionReference(TestCase):
             'second': {'order': 1},
             'third': {'order': 3}
         }}
-        docs = list(fs.collection('foo').order_by('order').limit(2).get())
+        docs = list(fs.collection('foo').order_by('order').limit(2).stream())
         self.assertEqual({'order': 1}, docs[0].to_dict())
         self.assertEqual({'order': 2}, docs[1].to_dict())
 

--- a/tests/test_collection_reference.py
+++ b/tests/test_collection_reference.py
@@ -1,6 +1,7 @@
 from unittest import TestCase
 
 from mockfirestore import MockFirestore, DocumentReference, DocumentSnapshot
+from mockfirestore.main import AlreadyExists
 
 
 class TestCollectionReference(TestCase):
@@ -183,3 +184,18 @@ class TestCollectionReference(TestCase):
             doc_reference = doc_snapshot.reference
             subcollection = doc_reference.collection('order')
             self.assertIs(subcollection.parent, doc_reference)
+
+    def test_collection_addDocument(self):
+        fs = MockFirestore()
+        fs._data = {'foo': {}}
+        doc_id = 'bar'
+        doc_content = {'id': doc_id, 'xy': 'z'}
+        timestamp, doc_ref = fs.collection('foo').add(doc_content)
+        self.assertEqual(doc_content, doc_ref.get().to_dict())
+
+        doc = fs.collection('foo').document(doc_id).get().to_dict()
+        self.assertEqual(doc_content, doc)
+
+        with self.assertRaises(AlreadyExists):
+            fs.collection('foo').add(doc_content)
+

--- a/tests/test_document_reference.py
+++ b/tests/test_document_reference.py
@@ -119,3 +119,13 @@ class TestDocumentReference(TestCase):
         fs.collection('foo').document('first').delete()
         doc = fs.collection('foo').document('first').get()
         self.assertEqual(False, doc.exists)
+
+    def test_document_parent(self):
+        fs = MockFirestore()
+        fs._data = {'foo': {
+            'first': {'id': 1}
+        }}
+        coll = fs.collection('foo')
+        document = coll.document('first')
+        self.assertIs(document.parent, coll)
+

--- a/tests/test_document_snapshot.py
+++ b/tests/test_document_snapshot.py
@@ -27,3 +27,13 @@ class TestDocumentSnapshot(TestCase):
         }}
         doc = fs.collection('foo').document('second').get()
         self.assertFalse(doc.exists)
+
+    def test_documentSnapshot_reference(self):
+        fs = MockFirestore()
+        fs._data = {'foo': {
+            'first': {'id': 1}
+        }}
+        doc_ref = fs.collection('foo').document('second')
+        doc_snapshot = doc_ref.get()
+        self.assertIs(doc_ref, doc_snapshot.reference)
+

--- a/tests/test_timestamp.py
+++ b/tests/test_timestamp.py
@@ -1,0 +1,15 @@
+import unittest
+from datetime import datetime as dt
+
+from mockfirestore.main import Timestamp
+
+
+class TestTimestamp(unittest.TestCase):
+    def test_timestamp(self):
+        dt_timestamp = dt.now().timestamp()
+        timestamp = Timestamp(dt_timestamp)
+
+        seconds, nanos = str(dt_timestamp).split('.')
+        self.assertEqual(seconds, timestamp.seconds)
+        self.assertEqual(nanos, timestamp.nanos)
+


### PR DESCRIPTION
- `DocumentSnapshot` now includes the property `reference`, which points to its `DocumentReference` [python-firestore docs](https://googleapis.dev/python/firestore/latest/document.html#google.cloud.firestore_v1.document.DocumentSnapshot)
  * To allow that, `Query` now also retains a reference to its parent `CollectionReference` object. To that end, the `Query` class had to be significantly refactored in order to "lazify" operations from methods such as `where`, `limit`, and `order_by`, and only apply them to the data from `CollectionReference` once those data are actually requested. As far as I understand, this is close in spirit to how it's done in `python-firestore`
  * The `CollectionReference` class also had to be refactored to account for the new behaviour of `Query`
- `CollectionReference` now also implements `stream`, which returns a generator of `DocumentSnapshot`s
- python-firestore has deprecated `{CollectionReference/Query}.get` in favor of `stream`. This PR adds `stream` to both, and changes all code that previously used `get` (including tests) to use `stream`. `get` still works, but prints a `DeprecationWarning`