### PR TITLE
feat: added start_at, start_after, end_at, end_before functions to collections

### DIFF
--- a/mockfirestore/main.py
+++ b/mockfirestore/main.py
@@ -141,7 +141,7 @@ class Query:
 
         for field, compare, value in self._field_filters:
             doc_snapshots = [doc_snapshot for doc_snapshot in doc_snapshots
-                             if compare(doc_snapshot.to_dict()[field], value)]
+                             if compare(doc_snapshot.to_dict().get(field), value)]
 
         if self.orders:
             for key, direction in self.orders:

--- a/mockfirestore/main.py
+++ b/mockfirestore/main.py
@@ -192,7 +192,7 @@ class Query:
         self._end_at = (document_fields, False)
         return self
     
-    def _cursor_helper(self, document_fields: dict, doc_snapshot: Iterator[List], before: bool, start: bool) -> 'Query':
+    def _cursor_helper(self, document_fields: dict, doc_snapshot: Iterator[List], before: bool, start: bool):
         docs = deepcopy(doc_snapshot)
         for idx, doc in enumerate(doc_snapshot):
             index = None

--- a/mockfirestore/main.py
+++ b/mockfirestore/main.py
@@ -127,7 +127,7 @@ class Query:
         self._field_filters = []
         self.orders = list(orders)
         self._limit = limit
-        self.offset = offset
+        self._offset = offset
         self._start_at = start_at
         self._end_at = end_at
         self.all_descendants = all_descendants
@@ -156,6 +156,9 @@ class Query:
             document_fields, before = self._end_at
             doc_snapshots = self._apply_cursor(document_fields, doc_snapshots, before, False)
 
+        if self._offset:
+            doc_snapshots = islice(doc_snapshots, self._offset, None)
+
         if self._limit:
             doc_snapshots = islice(doc_snapshots, self._limit)
 
@@ -180,6 +183,10 @@ class Query:
 
     def limit(self, limit_amount: int) -> 'Query':
         self._limit = limit_amount
+        return self
+
+    def offset(self, offset_amount: int) -> 'Query':
+        self._offset = offset_amount
         return self
 
     def start_at(self, document_fields: dict) -> 'Query':
@@ -275,6 +282,10 @@ class CollectionReference:
 
     def limit(self, limit_amount: int) -> Query:
         query = Query(self, limit=limit_amount)
+        return query
+
+    def offset(self, offset: int) -> Query:
+        query = Query(self, offset=offset)
         return query
 
     def start_at(self, document_fields: dict) -> Query:

--- a/mockfirestore/main.py
+++ b/mockfirestore/main.py
@@ -197,7 +197,7 @@ class Query:
         for idx, doc in enumerate(doc_snapshot):
             index = None
             for k,v in document_fields.items():
-                if doc.to_dict()[k] == v:
+                if doc.to_dict().get(k, None) == v:
                     index = idx
                 else:
                     index = None

--- a/tests/test_collection_reference.py
+++ b/tests/test_collection_reference.py
@@ -144,11 +144,33 @@ class TestCollectionReference(TestCase):
             'second': {'id': 2},
             'third': {'id': 3}
         }}
+        docs = list(fs.collection('foo').start_at({'id': 2}).stream())
+        self.assertEqual({'id': 2}, docs[0].to_dict())
+        self.assertEqual(2, len(docs))
+    
+    def test_collection_start_at_order_by(self):
+        fs = MockFirestore()
+        fs._data = {'foo': {
+            'first': {'id': 1},
+            'second': {'id': 2},
+            'third': {'id': 3}
+        }}
         docs = list(fs.collection('foo').order_by('id').start_at({'id': 2}).stream())
         self.assertEqual({'id': 2}, docs[0].to_dict())
         self.assertEqual(2, len(docs))
 
     def test_collection_start_after(self):
+        fs = MockFirestore()
+        fs._data = {'foo': {
+            'first': {'id': 1},
+            'second': {'id': 2},
+            'third': {'id': 3}
+        }}
+        docs = list(fs.collection('foo').start_after({'id': 2}).stream())
+        self.assertEqual({'id': 3}, docs[0].to_dict())
+        self.assertEqual(1, len(docs))
+
+    def test_collection_start_after_order_by(self):
         fs = MockFirestore()
         fs._data = {'foo': {
             'first': {'id': 1},
@@ -166,6 +188,17 @@ class TestCollectionReference(TestCase):
             'second': {'id': 2},
             'third': {'id': 3}
         }}
+        docs = list(fs.collection('foo').end_before({'id': 2}).stream())
+        self.assertEqual({'id': 1}, docs[0].to_dict())
+        self.assertEqual(1, len(docs))
+
+    def test_collection_end_before_order_by(self):
+        fs = MockFirestore()
+        fs._data = {'foo': {
+            'first': {'id': 1},
+            'second': {'id': 2},
+            'third': {'id': 3}
+        }}
         docs = list(fs.collection('foo').order_by('id').end_before({'id': 2}).stream())
         self.assertEqual({'id': 1}, docs[0].to_dict())
         self.assertEqual(1, len(docs))
@@ -177,10 +210,21 @@ class TestCollectionReference(TestCase):
             'second': {'id': 2},
             'third': {'id': 3}
         }}
-        docs = list(fs.collection('foo').order_by('id').end_at({'id': 2}).stream())
+        docs = list(fs.collection('foo').end_at({'id': 2}).stream())
         self.assertEqual({'id': 2}, docs[1].to_dict())
         self.assertEqual(2, len(docs))
     
+    def test_collection_end_at_order_by(self):
+        fs = MockFirestore()
+        fs._data = {'foo': {
+            'first': {'id': 1},
+            'second': {'id': 2},
+            'third': {'id': 3}
+        }}
+        docs = list(fs.collection('foo').order_by('id').end_at({'id': 2}).stream())
+        self.assertEqual({'id': 2}, docs[1].to_dict())
+        self.assertEqual(2, len(docs))
+
     def test_collection_limitAndOrderBy(self):
         fs = MockFirestore()
         fs._data = {'foo': {

--- a/tests/test_collection_reference.py
+++ b/tests/test_collection_reference.py
@@ -144,7 +144,7 @@ class TestCollectionReference(TestCase):
             'second': {'id': 2},
             'third': {'id': 3}
         }}
-        docs = list(fs.collection('foo').order_by("id").start_at({"id": 2}).stream())
+        docs = list(fs.collection('foo').order_by('id').start_at({'id': 2}).stream())
         self.assertEqual({'id': 2}, docs[0].to_dict())
         self.assertEqual(2, len(docs))
 
@@ -155,7 +155,7 @@ class TestCollectionReference(TestCase):
             'second': {'id': 2},
             'third': {'id': 3}
         }}
-        docs = list(fs.collection('foo').start_after('second').stream())
+        docs = list(fs.collection('foo').order_by('id').start_after({'id': 2}).stream())
         self.assertEqual({'id': 3}, docs[0].to_dict())
         self.assertEqual(1, len(docs))
 
@@ -166,7 +166,7 @@ class TestCollectionReference(TestCase):
             'second': {'id': 2},
             'third': {'id': 3}
         }}
-        docs = list(fs.collection('foo').end_before('second').stream())
+        docs = list(fs.collection('foo').order_by('id').end_before({'id': 2}).stream())
         self.assertEqual({'id': 1}, docs[0].to_dict())
         self.assertEqual(1, len(docs))
 
@@ -177,7 +177,7 @@ class TestCollectionReference(TestCase):
             'second': {'id': 2},
             'third': {'id': 3}
         }}
-        docs = list(fs.collection('foo').end_at('second').stream())
+        docs = list(fs.collection('foo').order_by('id').end_at({'id': 2}).stream())
         self.assertEqual({'id': 2}, docs[1].to_dict())
         self.assertEqual(2, len(docs))
     

--- a/tests/test_collection_reference.py
+++ b/tests/test_collection_reference.py
@@ -137,6 +137,50 @@ class TestCollectionReference(TestCase):
         self.assertEqual({'id': 1}, docs[0].to_dict())
         self.assertEqual(1, len(docs))
 
+    def test_collection_start_at(self):
+        fs = MockFirestore()
+        fs._data = {'foo': {
+            'first': {'id': 1},
+            'second': {'id': 2},
+            'third': {'id': 3}
+        }}
+        docs = list(fs.collection('foo').start_at('second').stream())
+        self.assertEqual({'id': 2}, docs[0].to_dict())
+        self.assertEqual(2, len(docs))
+
+    def test_collection_start_after(self):
+        fs = MockFirestore()
+        fs._data = {'foo': {
+            'first': {'id': 1},
+            'second': {'id': 2},
+            'third': {'id': 3}
+        }}
+        docs = list(fs.collection('foo').start_after('second').stream())
+        self.assertEqual({'id': 3}, docs[0].to_dict())
+        self.assertEqual(1, len(docs))
+
+    def test_collection_end_before(self):
+        fs = MockFirestore()
+        fs._data = {'foo': {
+            'first': {'id': 1},
+            'second': {'id': 2},
+            'third': {'id': 3}
+        }}
+        docs = list(fs.collection('foo').end_before('second').stream())
+        self.assertEqual({'id': 1}, docs[0].to_dict())
+        self.assertEqual(1, len(docs))
+
+    def test_collection_end_at(self):
+        fs = MockFirestore()
+        fs._data = {'foo': {
+            'first': {'id': 1},
+            'second': {'id': 2},
+            'third': {'id': 3}
+        }}
+        docs = list(fs.collection('foo').end_at('second').stream())
+        self.assertEqual({'id': 2}, docs[1].to_dict())
+        self.assertEqual(2, len(docs))
+    
     def test_collection_limitAndOrderBy(self):
         fs = MockFirestore()
         fs._data = {'foo': {

--- a/tests/test_collection_reference.py
+++ b/tests/test_collection_reference.py
@@ -55,7 +55,7 @@ class TestCollectionReference(TestCase):
         fs = MockFirestore()
         fs._data = {'foo': {
             'first': {'valid': True},
-            'second': {'valid': False}
+            'second': {'gumby': False}
         }}
 
         docs = list(fs.collection('foo').where('valid', '==', True).stream())

--- a/tests/test_collection_reference.py
+++ b/tests/test_collection_reference.py
@@ -150,7 +150,6 @@ class TestCollectionReference(TestCase):
         self.assertEqual({'id': 3}, docs[1].to_dict())
         self.assertEqual(2, len(docs))
 
-
     def test_collection_orderby_offset(self):
         fs = MockFirestore()
         fs._data = {'foo': {

--- a/tests/test_collection_reference.py
+++ b/tests/test_collection_reference.py
@@ -144,7 +144,7 @@ class TestCollectionReference(TestCase):
             'second': {'id': 2},
             'third': {'id': 3}
         }}
-        docs = list(fs.collection('foo').start_at('second').stream())
+        docs = list(fs.collection('foo').order_by("id").start_at({"id": 2}).stream())
         self.assertEqual({'id': 2}, docs[0].to_dict())
         self.assertEqual(2, len(docs))
 

--- a/tests/test_collection_reference.py
+++ b/tests/test_collection_reference.py
@@ -137,6 +137,33 @@ class TestCollectionReference(TestCase):
         self.assertEqual({'id': 1}, docs[0].to_dict())
         self.assertEqual(1, len(docs))
 
+    def test_collection_offset(self):
+        fs = MockFirestore()
+        fs._data = {'foo': {
+            'first': {'id': 1},
+            'second': {'id': 2},
+            'third': {'id': 3}
+        }}
+        docs = list(fs.collection('foo').offset(1).stream())
+
+        self.assertEqual({'id': 2}, docs[0].to_dict())
+        self.assertEqual({'id': 3}, docs[1].to_dict())
+        self.assertEqual(2, len(docs))
+
+
+    def test_collection_orderby_offset(self):
+        fs = MockFirestore()
+        fs._data = {'foo': {
+            'first': {'id': 1},
+            'second': {'id': 2},
+            'third': {'id': 3}
+        }}
+        docs = list(fs.collection('foo').order_by("id").offset(1).stream())
+
+        self.assertEqual({'id': 2}, docs[0].to_dict())
+        self.assertEqual({'id': 3}, docs[1].to_dict())
+        self.assertEqual(2, len(docs))
+
     def test_collection_start_at(self):
         fs = MockFirestore()
         fs._data = {'foo': {

--- a/tests/test_document_reference.py
+++ b/tests/test_document_reference.py
@@ -9,8 +9,9 @@ class TestDocumentReference(TestCase):
         fs._data = {'foo': {
             'first': {'id': 1}
         }}
-        doc = fs.collection('foo').document('first').get().to_dict()
-        self.assertEqual({'id': 1}, doc)
+        doc = fs.collection('foo').document('first').get()
+        self.assertEqual({'id': 1}, doc.to_dict())
+        self.assertEqual('first', doc.id)
 
     def test_document_get_documentIdEqualsKey(self):
         fs = MockFirestore()


### PR DESCRIPTION
- added: `start_at` functionality to allow returning documents starting _at_ a specific cursor
- added: `start_after` functionality to allow returning documents starting _after_ a specific cursor
- added: `end_at` functionality to allow returning documents ending _up to_ a specific cursor
- added: `end_at` functionality to allow returning documents ending _before_ a specific cursor

Implemented missing functionality that allowed retrieving documents based on a cursor (id).