### PR TITLE
Add support for dot-separated field path in where()

### DIFF
--- a/mockfirestore/document.py
+++ b/mockfirestore/document.py
@@ -1,4 +1,6 @@
 from copy import deepcopy
+from functools import reduce
+import operator
 from typing import List, Dict, Any
 from mockfirestore._helpers import Timestamp, Document, Store, get_by_path, set_by_path, delete_by_path
 
@@ -23,6 +25,12 @@ class DocumentSnapshot:
     def create_time(self) -> Timestamp:
         timestamp = Timestamp.from_now()
         return timestamp
+
+    def _get_by_field_path(self, field_path: str) -> Any:
+        try:
+            return reduce(operator.getitem, field_path.split('.'), self._doc)
+        except KeyError:
+            return None
 
 
 class DocumentReference:
@@ -58,4 +66,3 @@ class DocumentReference:
         if name not in document:
             set_by_path(self._data, new_path, {})
         return CollectionReference(self._data, new_path, parent=self)
-

--- a/mockfirestore/query.py
+++ b/mockfirestore/query.py
@@ -29,7 +29,7 @@ class Query:
 
         for field, compare, value in self._field_filters:
             doc_snapshots = [doc_snapshot for doc_snapshot in doc_snapshots
-                             if compare(doc_snapshot.to_dict().get(field), value)]
+                             if compare(doc_snapshot._get_by_field_path(field), value)]
 
         if self.orders:
             for key, direction in self.orders:

--- a/tests/test_collection_reference.py
+++ b/tests/test_collection_reference.py
@@ -102,6 +102,27 @@ class TestCollectionReference(TestCase):
         self.assertEqual({'count': 1}, docs[0].to_dict())
         self.assertEqual({'count': 5}, docs[1].to_dict())
 
+    def test_collection_whereMissingField(self):
+        fs = MockFirestore()
+        fs._data = {'foo': {
+            'first': {'count': 1},
+            'second': {'count': 5}
+        }}
+
+        docs = list(fs.collection('foo').where('no_field', '==', 1).stream())
+        self.assertEqual(len(docs), 0)
+
+    def test_collection_whereNestedField(self):
+        fs = MockFirestore()
+        fs._data = {'foo': {
+            'first': {'nested': {'a': 1}},
+            'second': {'nested': {'a': 2}}
+        }}
+
+        docs = list(fs.collection('foo').where('nested.a', '==', 1).stream())
+        self.assertEqual(len(docs), 1)
+        self.assertEqual({'nested': {'a': 1}}, docs[0].to_dict())
+
     def test_collection_orderBy(self):
         fs = MockFirestore()
         fs._data = {'foo': {
@@ -311,4 +332,3 @@ class TestCollectionReference(TestCase):
 
         with self.assertRaises(AlreadyExists):
             fs.collection('foo').add(doc_content)
-


### PR DESCRIPTION
Query's where() method takes a dot-separated field path for querying maps inside of documents.  This change adds support for this.  The change also avoids raising KeyError when encountering a document that doesn't have the field specified in where().

This changes (ab)uses get_by_path to read the value out of the document.  If that's not acceptable, I could add a private method to DocumentSnapshot to get the value by field path instead.