### PR TITLE
update() should fail when the document doesn't exist

### DIFF
--- a/mockfirestore/__init__.py
+++ b/mockfirestore/__init__.py
@@ -3,9 +3,9 @@
 # try to import gcloud exceptions
 # and if gcloud is not installed, define our own
 try:
-    from google.cloud.exceptions import ClientError, Conflict, AlreadyExists
+    from google.cloud.exceptions import ClientError, Conflict, NotFound, AlreadyExists
 except ImportError:
-    from mockfirestore.exceptions import ClientError, Conflict, AlreadyExists
+    from mockfirestore.exceptions import ClientError, Conflict, NotFound, AlreadyExists
 
 from mockfirestore.client import MockFirestore
 from mockfirestore.document import DocumentSnapshot, DocumentReference

--- a/mockfirestore/__init__.py
+++ b/mockfirestore/__init__.py
@@ -3,7 +3,7 @@
 # try to import gcloud exceptions
 # and if gcloud is not installed, define our own
 try:
-    from google.cloud.exceptions import ClientError, Conflict, NotFound, AlreadyExists
+    from google.api_core.exceptions import ClientError, Conflict, NotFound, AlreadyExists
 except ImportError:
     from mockfirestore.exceptions import ClientError, Conflict, NotFound, AlreadyExists
 

--- a/mockfirestore/document.py
+++ b/mockfirestore/document.py
@@ -2,6 +2,7 @@ from copy import deepcopy
 from functools import reduce
 import operator
 from typing import List, Dict, Any
+from mockfirestore import NotFound
 from mockfirestore._helpers import Timestamp, Document, Store, get_by_path, set_by_path, delete_by_path
 
 
@@ -57,7 +58,10 @@ class DocumentReference:
             set_by_path(self._data, self._path, data)
 
     def update(self, data: Dict[str, Any]):
-        get_by_path(self._data, self._path).update(data)
+        document = get_by_path(self._data, self._path)
+        if document == {}:
+            raise NotFound('No document to update: {}'.format(self._path))
+        document.update(data)
 
     def collection(self, name) -> 'CollectionReference':
         from mockfirestore.collection import CollectionReference

--- a/mockfirestore/exceptions.py
+++ b/mockfirestore/exceptions.py
@@ -13,5 +13,9 @@ class Conflict(ClientError):
     code = 409
 
 
+class NotFound(ClientError):
+    code = 404
+
+
 class AlreadyExists(Conflict):
     pass

--- a/tests/test_document_reference.py
+++ b/tests/test_document_reference.py
@@ -1,6 +1,6 @@
 from unittest import TestCase
 
-from mockfirestore import MockFirestore
+from mockfirestore import MockFirestore, NotFound
 
 
 class TestDocumentReference(TestCase):
@@ -111,6 +111,13 @@ class TestDocumentReference(TestCase):
         fs.collection('foo').document('first').update({'id': 2})
         doc = fs.collection('foo').document('first').get().to_dict()
         self.assertEqual({'id': 2}, doc)
+    
+    def test_document_update_documentDoesNotExist(self):
+        fs = MockFirestore()
+        with self.assertRaises(NotFound):
+            fs.collection('foo').document('nonexistent').update({'id': 2})
+        docsnap = fs.collection('foo').document('nonexistent').get()
+        self.assertFalse(docsnap.exists)
 
     def test_document_delete_documentDoesNotExistAfterDelete(self):
         fs = MockFirestore()


### PR DESCRIPTION
The firestore API raises a `NotFound` exception if you try to update a document that hasn't been created yet.  But mockfirestore was instead updating the (empty) doc successfully.

This is not a completely perfect fix.  `mockfirestore.CollectionReference.document()` still creates an empty document even without a `set()` or similar.  So we can't tell the difference between an empty document and a non-existent document.  But fixing that problem would be much more involved.

This also fixes a bug that prevented successful import of the Google API exceptions.