### PR TITLE
Stored data should be isolated from callers.

### DIFF
--- a/mockfirestore/document.py
+++ b/mockfirestore/document.py
@@ -53,15 +53,15 @@ class DocumentReference:
 
     def set(self, data: Dict, merge=False):
         if merge:
-            self.update(data)
+            self.update(deepcopy(data))
         else:
-            set_by_path(self._data, self._path, data)
+            set_by_path(self._data, self._path, deepcopy(data))
 
     def update(self, data: Dict[str, Any]):
         document = get_by_path(self._data, self._path)
         if document == {}:
             raise NotFound('No document to update: {}'.format(self._path))
-        document.update(data)
+        document.update(deepcopy(data))
 
     def collection(self, name) -> 'CollectionReference':
         from mockfirestore.collection import CollectionReference

--- a/tests/test_document_reference.py
+++ b/tests/test_document_reference.py
@@ -94,6 +94,15 @@ class TestDocumentReference(TestCase):
         doc = fs.collection('foo').document('first').get().to_dict()
         self.assertEqual({'new_id': 1}, doc)
 
+    def test_document_set_isolation(self):
+        fs = MockFirestore()
+        fs._data = {'foo': {}}
+        doc_content = {'id': 'bar'}
+        fs.collection('foo').document('bar').set(doc_content)
+        doc_content['id'] = 'new value'
+        doc = fs.collection('foo').document('bar').get().to_dict()
+        self.assertEqual({'id': 'bar'}, doc)
+
     def test_document_update_addNewValue(self):
         fs = MockFirestore()
         fs._data = {'foo': {
@@ -118,6 +127,17 @@ class TestDocumentReference(TestCase):
             fs.collection('foo').document('nonexistent').update({'id': 2})
         docsnap = fs.collection('foo').document('nonexistent').get()
         self.assertFalse(docsnap.exists)
+
+    def test_document_update_isolation(self):
+        fs = MockFirestore()
+        fs._data = {'foo': {
+            'first': {'nested': {'id': 1}}
+        }}
+        update_doc = {'nested': {'id': 2}}
+        fs.collection('foo').document('first').update(update_doc)
+        update_doc['nested']['id'] = 3
+        doc = fs.collection('foo').document('first').get().to_dict()
+        self.assertEqual({'nested': {'id': 2}}, doc)
 
     def test_document_delete_documentDoesNotExistAfterDelete(self):
         fs = MockFirestore()

--- a/tests/test_document_snapshot.py
+++ b/tests/test_document_snapshot.py
@@ -12,6 +12,15 @@ class TestDocumentSnapshot(TestCase):
         doc = fs.collection('foo').document('first').get()
         self.assertEqual({'id': 1}, doc.to_dict())
 
+    def test_documentSnapshot_toDict_isolation(self):
+        fs = MockFirestore()
+        fs._data = {'foo': {
+            'first': {'id': 1}
+        }}
+        doc_dict = fs.collection('foo').document('first').get().to_dict()
+        fs._data['foo']['first']['id'] = 2
+        self.assertEqual({'id': 1}, doc_dict)
+
     def test_documentSnapshot_exists(self):
         fs = MockFirestore()
         fs._data = {'foo': {


### PR DESCRIPTION
Make a copy of dicts passed in to set() and update() so that callers don't hold references into MockFirestore._data that they can modify.  to_dict() already returns a copy, but add a test to verify this.