### PR TITLE
Array contains queries implementation

### DIFF
--- a/mockfirestore/query.py
+++ b/mockfirestore/query.py
@@ -126,3 +126,7 @@ class Query:
             return lambda x, y: x >= y
         elif op == 'in':
             return lambda x, y: x in y
+        elif op == 'array_contains':
+            return lambda x, y: y in x
+        elif op == 'array_contains_any':
+            return lambda x, y: any([val in y for val in x])

--- a/tests/test_collection_reference.py
+++ b/tests/test_collection_reference.py
@@ -137,6 +137,23 @@ class TestCollectionReference(TestCase):
         self.assertEqual({'field': 'a1'}, docs[0].to_dict())
         self.assertEqual({'field': 'a3'}, docs[1].to_dict())
 
+    def test_collection_whereArrayContains(self):
+        fs = MockFirestore()
+        fs._data = {'foo': {
+            'first': {'field': ['val4']},
+            'second': {'field': ['val3', 'val2']},
+            'third': {'field': ['val3', 'val2', 'val1']}
+        }}
+
+        docs = list(fs.collection('foo').where('field', 'array_contains', 'val1').stream())
+        self.assertEqual(len(docs), 1)
+        self.assertEqual(docs[0].to_dict(), {'field': ['val3', 'val2', 'val1']})
+
+        contains_any_docs = list(fs.collection('foo').where('field', 'array_contains_any', ['val1', 'val4']).stream())
+        self.assertEqual(len(contains_any_docs), 2)
+        self.assertIn({'field': ['val4']}, contains_any_docs)
+        self.assertIn({'field': ['val3', 'val2', 'val1']}, contains_any_docs)
+
     def test_collection_orderBy(self):
         fs = MockFirestore()
         fs._data = {'foo': {


### PR DESCRIPTION
Implemented `array_contains` and `array_contains_any` compare functions to allow queries for items in lists.