### PR TITLE
Adding a get method to DocumentSnapshot.

### DIFF
--- a/mockfirestore/document.py
+++ b/mockfirestore/document.py
@@ -33,6 +33,9 @@ class DocumentSnapshot:
         except KeyError:
             return None
 
+    def get(self, field_path):
+        return self._get_by_field_path(field_path)
+
 
 class DocumentReference:
     def __init__(self, data: Store, path: List[str],

--- a/mockfirestore/document.py
+++ b/mockfirestore/document.py
@@ -27,14 +27,17 @@ class DocumentSnapshot:
         timestamp = Timestamp.from_now()
         return timestamp
 
+    def get(self, field_path: str) -> Any:
+        if not self._doc:
+            return None
+        else:
+            return reduce(operator.getitem, field_path.split('.'), self._doc)
+
     def _get_by_field_path(self, field_path: str) -> Any:
         try:
-            return reduce(operator.getitem, field_path.split('.'), self._doc)
+            return self.get(field_path)
         except KeyError:
             return None
-
-    def get(self, field_path):
-        return self._get_by_field_path(field_path)
 
 
 class DocumentReference:

--- a/mockfirestore/document.py
+++ b/mockfirestore/document.py
@@ -28,7 +28,7 @@ class DocumentSnapshot:
         return timestamp
 
     def get(self, field_path: str) -> Any:
-        if not self._doc:
+        if not self.exists:
             return None
         else:
             return reduce(operator.getitem, field_path.split('.'), self._doc)

--- a/tests/test_document_snapshot.py
+++ b/tests/test_document_snapshot.py
@@ -46,3 +46,22 @@ class TestDocumentSnapshot(TestCase):
         doc_snapshot = doc_ref.get()
         self.assertIs(doc_ref, doc_snapshot.reference)
 
+    def test_documentSnapshot_get_by_existing_field_path(self):
+        fs = MockFirestore()
+        fs._data = {'foo': {
+            'first': {'id': 1, 'contact': {
+                'email': 'email@test.com'
+            }}
+        }}
+        doc = fs.collection('foo').document('first').get()
+        self.assertEqual(doc.get('contact.email'), 'email@test.com')
+
+    def test_documentSnapshot_get_by_non_existing_field_path(self):
+        fs = MockFirestore()
+        fs._data = {'foo': {
+            'first': {'id': 1, 'contact': {
+                'email': 'email@test.com'
+            }}
+        }}
+        doc = fs.collection('foo').document('first').get()
+        self.assertIsNone(doc.get('contact.phone'))

--- a/tests/test_document_snapshot.py
+++ b/tests/test_document_snapshot.py
@@ -76,3 +76,15 @@ class TestDocumentSnapshot(TestCase):
         }}
         doc = fs.collection('foo').document('second').get()
         self.assertIsNone(doc.get('contact.email'))
+
+    def test_documentSnapshot_get_returns_a_copy_of_the_data_stored(self):
+        fs = MockFirestore()
+        fs._data = {'foo': {
+            'first': {'id': 1, 'contact': {
+                'email': 'email@test.com'
+            }}
+        }}
+        doc = fs.collection('foo').document('first').get()
+        self.assertIsNot(
+            doc.get('contact'),fs._data['foo']['first']['contact']
+        )

--- a/tests/test_document_snapshot.py
+++ b/tests/test_document_snapshot.py
@@ -64,4 +64,15 @@ class TestDocumentSnapshot(TestCase):
             }}
         }}
         doc = fs.collection('foo').document('first').get()
-        self.assertIsNone(doc.get('contact.phone'))
+        with self.assertRaises(KeyError):
+            doc.get('contact.phone')
+
+    def test_documentSnapshot_get_in_an_non_existing_document(self):
+        fs = MockFirestore()
+        fs._data = {'foo': {
+            'first': {'id': 1, 'contact': {
+                'email': 'email@test.com'
+            }}
+        }}
+        doc = fs.collection('foo').document('second').get()
+        self.assertIsNone(doc.get('contact.email'))


### PR DESCRIPTION
I did this method according to the [DocumentSnapshot get method](https://github.com/googleapis/python-firestore/blob/447192313ad3093d9fd8c24805aea957eaf1ab7d/google/cloud/firestore_v1/document.py#L621), that is:
- returning **a copy** of the value stored
- returning `None` if the document doesn't exists
- raising a `KeyError` if the field path were not found

This is actually a refactoring of my other PR(#22) adding tests and all.

I did not want to change the `_get_field_by_path` because it is used in other parts of the code, and other people can be using it.

This also closes #15 issue.
