### PR TITLE
Fix set with merge for new document

### DIFF
--- a/mockfirestore/document.py
+++ b/mockfirestore/document.py
@@ -6,6 +6,7 @@ from mockfirestore import NotFound
 from mockfirestore._helpers import (
     Timestamp, Document, Store, get_by_path, set_by_path, delete_by_path, get_document_iterator
 )
+from google.api_core.exceptions import NotFound
 
 
 class DocumentSnapshot:
@@ -70,7 +71,10 @@ class DocumentReference:
 
     def set(self, data: Dict, merge=False):
         if merge:
-            self.update(deepcopy(data))
+            try:
+                self.update(deepcopy(data))
+            except NotFound:
+                self.set(data)
         else:
             set_by_path(self._data, self._path, deepcopy(data))
 

--- a/mockfirestore/document.py
+++ b/mockfirestore/document.py
@@ -6,7 +6,6 @@ from mockfirestore import NotFound
 from mockfirestore._helpers import (
     Timestamp, Document, Store, get_by_path, set_by_path, delete_by_path, get_document_iterator
 )
-from google.api_core.exceptions import NotFound
 
 
 class DocumentSnapshot:

--- a/tests/test_document_reference.py
+++ b/tests/test_document_reference.py
@@ -87,6 +87,12 @@ class TestDocumentReference(TestCase):
         doc = fs.collection('foo').document('first').get().to_dict()
         self.assertEqual({'id': 1, 'updated': True}, doc)
 
+    def test_document_set_mergeNewValueForNonExistentDoc(self):
+        fs = MockFirestore()
+        fs.collection('foo').document('first').set({'updated': True}, merge=True)
+        doc = fs.collection('foo').document('first').get().to_dict()
+        self.assertEqual({'updated': True}, doc)
+
     def test_document_set_overwriteValue(self):
         fs = MockFirestore()
         fs._data = {'foo': {


### PR DESCRIPTION
Correctly creates a new document when merge=True but the document doesn't exist.

Fixes #27