### PR TITLE
Add support for `!=` operator.

### DIFF
--- a/mockfirestore/query.py
+++ b/mockfirestore/query.py
@@ -121,6 +121,8 @@ class Query:
     def _compare_func(self, op: str) -> Callable[[T, T], bool]:
         if op == '==':
             return lambda x, y: x == y
+        elif op == '!=':
+            return lambda x, y: x != y
         elif op == '<':
             return lambda x, y: x < y
         elif op == '<=':

--- a/tests/test_collection_reference.py
+++ b/tests/test_collection_reference.py
@@ -81,6 +81,16 @@ class TestCollectionReference(TestCase):
         docs = list(fs.collection('foo').where('valid', '==', True).stream())
         self.assertEqual({'valid': True}, docs[0].to_dict())
 
+    def test_collection_whereNotEquals(self):
+        fs = MockFirestore()
+        fs._data = {'foo': {
+            'first': {'count': 1},
+            'second': {'count': 5}
+        }}
+
+        docs = list(fs.collection('foo').where('count', '!=', 1).stream())
+        self.assertEqual({'count': 5}, docs[0].to_dict())
+
     def test_collection_whereLessThan(self):
         fs = MockFirestore()
         fs._data = {'foo': {


### PR DESCRIPTION
Fixes #43.

Firestore supports != operators now: https://firebase.google.com/docs/firestore/query-data/queries#query_operators