### PR TITLE
Issue #17: Implement `collection_group` queries

### DIFF
--- a/mockfirestore/client.py
+++ b/mockfirestore/client.py
@@ -1,4 +1,4 @@
-from typing import Iterable, Sequence, Optional, Collection
+from typing import Iterable, Sequence, Optional
 from mockfirestore.collection import CollectionReference
 from mockfirestore.document import DocumentReference, DocumentSnapshot
 from mockfirestore.transaction import Transaction
@@ -6,12 +6,7 @@ from mockfirestore.transaction import Transaction
 
 class MockFirestore:
 
-    def __init__(self, collection_groups: Optional[Collection[str]] = None) -> None:
-        """
-        Args:
-            collection_groups: The collection group names. If none, collection group queries are not supported.
-        """
-        self._collection_groups = collection_groups or set()
+    def __init__(self) -> None:
         self._data = {}
 
     def _ensure_path(self, path):
@@ -52,9 +47,6 @@ class MockFirestore:
     def collection_group(self, name: str) -> CollectionReference:
         if '/' in name:
             raise Exception("Collection group names cannot contain '/'")
-
-        if name not in self._collection_groups:
-            raise Exception(f"Collection group {name} must be specified in the constructor")
 
         collection_group_data = _get_collection_group_data(self._data, name)
         data = {name: collection_group_data}

--- a/tests/test_collection_reference.py
+++ b/tests/test_collection_reference.py
@@ -64,7 +64,7 @@ class TestCollectionReference(TestCase):
 
     def test_collection_get_collectionGroup(self):
         subcollection = 'bar'
-        fs = MockFirestore(collection_groups={subcollection})
+        fs = MockFirestore()
         fs._data = {'foo': {
             'first': {
                 'id': 1,
@@ -85,7 +85,7 @@ class TestCollectionReference(TestCase):
 
     def test_collection_get_collectionGroup_collectionDoesNotExist(self):
         subcollection = 'bar'
-        fs = MockFirestore(collection_groups={subcollection})
+        fs = MockFirestore()
         fs._data = {'foo': {
             'first': {'id': 1}
         }}

--- a/tests/test_collection_reference.py
+++ b/tests/test_collection_reference.py
@@ -62,6 +62,36 @@ class TestCollectionReference(TestCase):
         docs = list(fs.collection('foo/first/bar').stream())
         self.assertEqual([], docs)
 
+    def test_collection_get_collectionGroup(self):
+        subcollection = 'bar'
+        fs = MockFirestore(collection_groups={subcollection})
+        fs._data = {'foo': {
+            'first': {
+                'id': 1,
+                subcollection: {
+                    'first_nested': {'id': 1.1}
+                }
+            },
+            'second': {
+                'id': 2,
+                subcollection: {
+                    'second_nested': {'id': 2.1}
+                }
+            }
+        }}
+        docs = sorted(list(fs.collection_group(subcollection).stream()), key=lambda doc: doc.id)
+        self.assertEqual({'id': 1.1}, docs[0].to_dict())
+        self.assertEqual({'id': 2.1}, docs[1].to_dict())
+
+    def test_collection_get_collectionGroup_collectionDoesNotExist(self):
+        subcollection = 'bar'
+        fs = MockFirestore(collection_groups={subcollection})
+        fs._data = {'foo': {
+            'first': {'id': 1}
+        }}
+        docs = list(fs.collection_group(subcollection).stream())
+        self.assertEqual([], docs)
+
     def test_collection_get_ordersByAscendingDocumentId_byDefault(self):
         fs = MockFirestore()
         fs._data = {'foo': {


### PR DESCRIPTION
Issue #17: Implement `collection_group` queries

Implement [collection_group](https://firebase.google.com/docs/firestore/query-data/queries#collection-group-query) queries. A collection group is a combination of subcollections that may be stored under separate documents but queried as if they were a single collection.