### PR TITLE
Implement `collection_group` queries

### DIFF
--- a/mockfirestore/_helpers.py
+++ b/mockfirestore/_helpers.py
@@ -28,7 +28,13 @@ def get_by_path(data: Dict[str, T], path: Sequence[str], create_nested: bool = F
 
 def set_by_path(data: Dict[str, T], path: Sequence[str], value: T, create_nested: bool = True):
     """Set a value in a nested object in root by item sequence."""
-    get_by_path(data, path[:-1], create_nested=True)[path[-1]] = value
+    data_nested = data
+    for key in path[:-1]:
+        new_data_nested = data_nested.setdefault(key, {})
+        if not isinstance(new_data_nested, dict):
+            data_nested[key] = {}
+        data_nested = data_nested[key]
+    data_nested[path[-1]] = value
 
 
 def delete_by_path(data: Dict[str, T], path: Sequence[str]):

--- a/mockfirestore/client.py
+++ b/mockfirestore/client.py
@@ -1,4 +1,4 @@
-from typing import Iterable, Sequence, Optional, Collection
+from typing import Iterable, Sequence, Optional
 from mockfirestore.collection import CollectionReference
 from mockfirestore.document import DocumentReference, DocumentSnapshot
 from mockfirestore.transaction import Transaction
@@ -6,12 +6,7 @@ from mockfirestore.transaction import Transaction
 
 class MockFirestore:
 
-    def __init__(self, collection_groups: Optional[Collection[str]] = None) -> None:
-        """
-        Args:
-            collection_groups: The collection group names. If none, collection group queries are not supported.
-        """
-        self._collection_groups = collection_groups or set()
+    def __init__(self) -> None:
         self._data = {}
 
     def _ensure_path(self, path):
@@ -52,9 +47,6 @@ class MockFirestore:
     def collection_group(self, name: str) -> CollectionReference:
         if '/' in name:
             raise Exception("Collection group names cannot contain '/'")
-
-        if name not in self._collection_groups:
-            raise Exception(f"Collection group {name} must be specified in the constructor")
 
         collection_group_data = _get_collection_group_data(self._data, name)
         data = {name: collection_group_data}

--- a/mockfirestore/client.py
+++ b/mockfirestore/client.py
@@ -1,6 +1,7 @@
 from typing import Iterable, Sequence, Optional
 from mockfirestore.collection import CollectionReference
 from mockfirestore.document import DocumentReference, DocumentSnapshot
+from mockfirestore.query import CollectionGroup
 from mockfirestore.transaction import Transaction
 
 
@@ -44,14 +45,18 @@ class MockFirestore:
                 self._data[name] = {}
             return CollectionReference(self._data, [name])
 
-    def collection_group(self, name: str) -> CollectionReference:
-        if '/' in name:
-            raise Exception("Collection group names cannot contain '/'")
+    def collection_group(self, collection_id: str) -> CollectionGroup:
+        if '/' in collection_id:
+            raise ValueError(
+                "Invalid collection_id "
+                + collection_id
+                + ". Collection IDs must not contain '/'."
+            )
 
-        collection_group_data = _get_collection_group_data(self._data, name)
-        data = {name: collection_group_data}
+        collection_group_data = _get_collection_group_data(self._data, collection_id)
+        data = {collection_id: collection_group_data}
 
-        return CollectionReference(data, [name])
+        return CollectionGroup(CollectionReference(data, [collection_id]))
 
     def collections(self) -> Sequence[CollectionReference]:
         return [CollectionReference(self._data, [collection_name]) for collection_name in self._data]

--- a/mockfirestore/collection.py
+++ b/mockfirestore/collection.py
@@ -49,7 +49,13 @@ class CollectionReference:
         query = Query(self, orders=[(key, direction)])
         return query
 
-    def limit(self, limit_amount: int) -> Query:
+    def limit(self, limit_amount: Optional[int]) -> Query:
+        if not isinstance(limit_amount, (int, type(None))):
+            raise TypeError(
+                f"TypeError: Cannot set google.protobuf.Int32Value.value to {limit_amount}:"
+                f" {limit_amount} has type {type(limit_amount)},"
+                f" but expected one of: ({int},) for field Int32Value.value"
+            )
         query = Query(self, limit=limit_amount)
         return query
 

--- a/mockfirestore/query.py
+++ b/mockfirestore/query.py
@@ -137,3 +137,8 @@ class Query:
             return lambda x, y: y in x
         elif op == 'array_contains_any':
             return lambda x, y: any([val in y for val in x])
+
+
+class CollectionGroup(Query):
+    def get_partitions(self, *_, **__):
+        raise NotImplementedError

--- a/mockfirestore/query.py
+++ b/mockfirestore/query.py
@@ -69,7 +69,7 @@ class Query:
         self.orders.append((key, direction))
         return self
 
-    def limit(self, limit_amount: int) -> 'Query':
+    def limit(self, limit_amount: Optional[int]) -> 'Query':
         self._limit = limit_amount
         return self
 

--- a/tests/test_collection_reference.py
+++ b/tests/test_collection_reference.py
@@ -64,7 +64,7 @@ class TestCollectionReference(TestCase):
 
     def test_collection_get_collectionGroup(self):
         subcollection = 'bar'
-        fs = MockFirestore(collection_groups={subcollection})
+        fs = MockFirestore()
         fs._data = {'foo': {
             'first': {
                 'id': 1,
@@ -85,7 +85,7 @@ class TestCollectionReference(TestCase):
 
     def test_collection_get_collectionGroup_collectionDoesNotExist(self):
         subcollection = 'bar'
-        fs = MockFirestore(collection_groups={subcollection})
+        fs = MockFirestore()
         fs._data = {'foo': {
             'first': {'id': 1}
         }}

--- a/tests/test_collection_reference.py
+++ b/tests/test_collection_reference.py
@@ -257,6 +257,25 @@ class TestCollectionReference(TestCase):
         self.assertEqual({'id': 1}, docs[0].to_dict())
         self.assertEqual(1, len(docs))
 
+    def test_collection_limitNone(self):
+        fs = MockFirestore()
+        fs._data = {'foo': {
+            'first': {'id': 1},
+            'second': {'id': 2}
+        }}
+        docs = list(fs.collection('foo').limit(None).stream())
+        self.assertEqual({'id': 1}, docs[0].to_dict())
+        self.assertEqual(2, len(docs))
+
+    def test_collection_limitInvalid(self):
+        fs = MockFirestore()
+        fs._data = {'foo': {
+            'first': {'id': 1},
+            'second': {'id': 2}
+        }}
+        with self.assertRaises(TypeError):
+            list(fs.collection('foo').limit(1.0).stream())
+
     def test_collection_offset(self):
         fs = MockFirestore()
         fs._data = {'foo': {

--- a/tests/test_collection_reference.py
+++ b/tests/test_collection_reference.py
@@ -62,6 +62,36 @@ class TestCollectionReference(TestCase):
         docs = list(fs.collection('foo/first/bar').stream())
         self.assertEqual([], docs)
 
+    def test_collection_get_collectionGroup(self):
+        subcollection = 'bar'
+        fs = MockFirestore(collection_groups={subcollection})
+        fs._data = {'foo': {
+            'first': {
+                'id': 1,
+                subcollection: {
+                    'first_nested': {'id': 1.1}
+                }
+            },
+            'second': {
+                'id': 2,
+                subcollection: {
+                    'second_nested': {'id': 2.1}
+                }
+            }
+        }}
+        docs = sorted(list(fs.collection_group(subcollection).stream()), key=lambda doc: doc.id)
+        self.assertEqual({'id': 1.1}, docs[0].to_dict())
+        self.assertEqual({'id': 2.1}, docs[1].to_dict())
+
+    def test_collection_get_collectionGroup_collectionDoesNotExist(self):
+        subcollection = 'bar'
+        fs = MockFirestore(collection_groups={subcollection})
+        fs._data = {'foo': {
+            'first': {'id': 1}
+        }}
+        docs = list(fs.collection_group(subcollection).stream())
+        self.assertEqual([], docs)
+
     def test_collection_get_ordersByAscendingDocumentId_byDefault(self):
         fs = MockFirestore()
         fs._data = {'foo': {

--- a/tests/test_document_reference.py
+++ b/tests/test_document_reference.py
@@ -298,7 +298,6 @@ class TestDocumentReference(TestCase):
         doc = fs.collection("foo").document("first").get().to_dict()
         self.assertEqual(doc, {"nested": {"subnested": {"value": [1, 3]}}, "other": None})
 
-
     def test_document_update_transformerSentinel(self):
         fs = MockFirestore()
         fs._data = {'foo': {
@@ -335,4 +334,3 @@ class TestDocumentReference(TestCase):
         )
         doc = fs.collection("foo").document("first").get().to_dict()
         self.assertEqual(doc["arr"], [1, 2, 3, 4])
-

--- a/tests/test_document_reference.py
+++ b/tests/test_document_reference.py
@@ -278,6 +278,15 @@ class TestDocumentReference(TestCase):
         doc = fs.collection("foo").document("first").get().to_dict()
         self.assertEqual(doc, {"nested": {"value": 2}, "other": None})
 
+    def test_document_update_nestedFieldDotNotationNestedNoneFieldCreation(self):
+        fs = MockFirestore()
+        fs._data = {"foo": {"first": {"other": None}}}  # non-existent nested field is created
+
+        fs.collection("foo").document("first").update({"other.value": 2})
+
+        doc = fs.collection("foo").document("first").get().to_dict()
+        self.assertEqual(doc, {"other": {"value": 2}})
+
     def test_document_update_nestedFieldDotNotationMultipleNested(self):
         fs = MockFirestore()
         fs._data = {"foo": {"first": {"other": None}}}


### PR DESCRIPTION
This addresses issue #17  

Other included enhancements:
- support setting nested dictionaries that were originally set with `None` values
- raise a `TypeError` if `limit` is called with the wrong type