### PR TITLE
Add Client.recursive_delete() and DocumentReference.collections() methods.

### DIFF
--- a/mockfirestore/client.py
+++ b/mockfirestore/client.py
@@ -59,4 +59,12 @@ class MockFirestore:
     def transaction(self, **kwargs) -> Transaction:
         return Transaction(self, **kwargs)
 
+    def recursive_delete(self,reference=None):
+        if reference == None:
+            return 
+        path = reference._path
+        cur = self._data
+        for p in path[:-1]:
+            cur = cur[p]
 
+        del cur[path[-1]]

--- a/mockfirestore/document.py
+++ b/mockfirestore/document.py
@@ -45,22 +45,7 @@ class DocumentSnapshot:
         else:
             return reduce(operator.getitem, field_path.split('.'), self._doc)
 
-    def collections(self) -> list['CollectionReference']:
-        from mockfirestore.collection import CollectionReference
-
-        l = []
-        paths = []
-        for k in self._doc:
-            if type(self._doc[k]) is dict:
-                l.append(self._doc[k])
-                paths.append([])
-
-        l2 = []
-        for c, p in zip(l, paths):
-            l2.append(CollectionReference(c, p, self.reference))
-
-        return l2
-
+    
 
     def _get_by_field_path(self, field_path: str) -> Any:
         try:
@@ -109,3 +94,19 @@ class DocumentReference:
         if name not in document:
             set_by_path(self._data, new_path, {})
         return CollectionReference(self._data, new_path, parent=self)
+
+    def collections(self) -> list['CollectionReference']:
+        from mockfirestore.collection import CollectionReference
+
+        doc = self.get()
+        paths = []
+        for k in doc._doc:
+            if type(doc._doc[k]) is dict:
+                paths.append(self._path + [k])
+
+        l = []
+        for p in paths:
+            l.append(CollectionReference(self._data, p, self))
+
+        return l
+

--- a/mockfirestore/document.py
+++ b/mockfirestore/document.py
@@ -2,7 +2,7 @@ from copy import deepcopy
 from functools import reduce
 import operator
 from typing import List, Dict, Any
-from mockfirestore import NotFound
+from mockfirestore import NotFound, collection
 from mockfirestore._helpers import (
     Timestamp, Document, Store, get_by_path, set_by_path, delete_by_path
 )
@@ -44,6 +44,23 @@ class DocumentSnapshot:
             return None
         else:
             return reduce(operator.getitem, field_path.split('.'), self._doc)
+
+    def collections(self) -> list['CollectionReference']:
+        from mockfirestore.collection import CollectionReference
+
+        l = []
+        paths = []
+        for k in self._doc:
+            if type(self._doc[k]) is dict:
+                l.append(self._doc[k])
+                paths.append([])
+
+        l2 = []
+        for c, p in zip(l, paths):
+            l2.append(CollectionReference(c, p, self.reference))
+
+        return l2
+
 
     def _get_by_field_path(self, field_path: str) -> Any:
         try:


### PR DESCRIPTION
There following methods were not yet implemented, I did my best to add them to help pass my unit tests. 

- [Client.recursive_delete()](https://googleapis.dev/python/firestore/latest/client.html#google.cloud.firestore_v1.client.Client.recursive_delete)

- [DocumentReference.collections() ](https://googleapis.dev/python/firestore/latest/document.html#google.cloud.firestore_v1.document.DocumentReference.collections)