### PR TITLE
Add equality and hash functions to DocumentReference to fix reference querying

### DIFF
--- a/mockfirestore/document.py
+++ b/mockfirestore/document.py
@@ -59,6 +59,15 @@ class DocumentReference:
         self._path = path
         self.parent = parent
 
+    def __hash__(self):
+        return hash(tuple(self._path))
+
+    def __eq__(self, other):
+        if not isinstance(other, self.__class__):
+            return False
+
+        return self._path == other._path
+
     @property
     def id(self):
         return self._path[-1]


### PR DESCRIPTION
Currently, querying documents by a reference field (e.g. `.where("reference_field", "==", reference)`) results in incorrect results due to document references not being compared properly. Even if there are documents with references that have the same path as the document reference passed into the query, no documents get returned. 

To address this, I've implemented `__eq__` and `__hash__` to be more similar to the actual `BaseDocumentReference` implementations (see [here](https://github.com/googleapis/python-firestore/blob/main/google/cloud/firestore_v1/base_document.py#L91) and [here](https://github.com/googleapis/python-firestore/blob/main/google/cloud/firestore_v1/base_document.py#L107)). `_client` is included in the original implementation, but is not present in mocked base document. Therefore, I've opted to only hash / compare `_path.`