### PR TITLE
Fix the testing workflow, add equality checks for references

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python ${{ matrix.python-version }}
-        uses: MatteoH2O1999/setup-python@v1
+        uses: MatteoH2O1999/setup-python@v0.1.1
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: MatteoH2O1999/setup-python@v1
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies

--- a/mockfirestore/document.py
+++ b/mockfirestore/document.py
@@ -77,6 +77,17 @@ class DocumentReference:
                 self.set(data)
         else:
             set_by_path(self._data, self._path, deepcopy(data))
+            
+    def __hash__(self):
+        return hash(tuple(self._path))
+
+    def __eq__(self, other):
+        if not isinstance(other, self.__class__):
+            return False
+
+        return self._path == other._path
+
+
 
     def update(self, data: Dict[str, Any]):
         document = get_by_path(self._data, self._path)

--- a/tests/test_collection_reference.py
+++ b/tests/test_collection_reference.py
@@ -195,12 +195,14 @@ class TestCollectionReference(TestCase):
 
     def test_collection_whereByReference(self):
         fs = MockFirestore()
-        fs._data = {'foo': {
-            'first': {'ref': fs.document('bar/first')},
-            'second': {'ref': fs.document('bar/second')}
+        fs._data = {
+        'foo': {
+            'otherDocRef': {'ref': fs.document('bar/first')},
         }}
 
-        docs = list(fs.collection('foo').where('ref', '==', fs.document('bar/first')).stream())
+        doc_ref = fs.collection('bar').document('first')
+
+        docs = list(fs.collection('foo').where('ref', '==', doc_ref).stream())
         self.assertEqual(len(docs), 1)
         self.assertEqual({'ref': fs.document('bar/first')}, docs[0].to_dict())
 

--- a/tests/test_collection_reference.py
+++ b/tests/test_collection_reference.py
@@ -193,6 +193,17 @@ class TestCollectionReference(TestCase):
         self.assertEqual({'field': ['val4']}, contains_any_docs[0].to_dict())
         self.assertEqual({'field': ['val3', 'val2', 'val1']}, contains_any_docs[1].to_dict())
 
+    def test_collection_whereByReference(self):
+        fs = MockFirestore()
+        fs._data = {'foo': {
+            'first': {'ref': fs.document('bar/first')},
+            'second': {'ref': fs.document('bar/second')}
+        }}
+
+        docs = list(fs.collection('foo').where('ref', '==', fs.document('bar/first')).stream())
+        self.assertEqual(len(docs), 1)
+        self.assertEqual({'ref': fs.document('bar/first')}, docs[0].to_dict())
+
     def test_collection_orderBy(self):
         fs = MockFirestore()
         fs._data = {'foo': {


### PR DESCRIPTION
One of the existing limitations with this library was the ability to query by document reference (which is something you can do in Firestore but not currently in this library). I have added this as it would be super useful. (copied from https://github.com/mdowds/python-mock-firestore/pull/68 and added a test)

In addition, the GitHub action for testing is currently broken due to an issue with lack of support for python 3.6 in the latest ubuntu image. I have changed the action to one that will build the python version if it is not able to be installed. 