### PR TITLE
Add collection id property and document collections() method

### DIFF
--- a/mockfirestore/collection.py
+++ b/mockfirestore/collection.py
@@ -14,6 +14,10 @@ class CollectionReference:
         self._path = path
         self.parent = parent
 
+    @property
+    def id(self):
+        return self._path[-1]
+
     def document(self, document_id: Optional[str] = None) -> DocumentReference:
         collection = get_by_path(self._data, self._path)
         if document_id is None:

--- a/mockfirestore/document.py
+++ b/mockfirestore/document.py
@@ -92,3 +92,11 @@ class DocumentReference:
         if name not in document:
             set_by_path(self._data, new_path, {})
         return CollectionReference(self._data, new_path, parent=self)
+
+    def collections(self):
+        """
+        Simulate the collections() function of a Firestore document. 
+        """
+        from mockfirestore.collection import CollectionReference
+        document = get_by_path(self._data, self._path)
+        return [CollectionReference(self._data, self._path + [name]) for name in document.keys() if isinstance(document[name], dict)]

--- a/tests/test_document_reference.py
+++ b/tests/test_document_reference.py
@@ -336,3 +336,21 @@ class TestDocumentReference(TestCase):
         doc = fs.collection("foo").document("first").get().to_dict()
         self.assertEqual(doc["arr"], [1, 2, 3, 4])
 
+    def test_document_get_collections(self):
+        fs = MockFirestore()
+        fs._data = fs._data = {'top_collection': {
+            'top_document': {
+                'id': 1,
+                'nested_collection1': {
+                    'nested_document': {'id': 1.1}
+                },
+                'nested_collection2': {
+                    'nested_document': {'id': 1.2}
+                }
+            }
+        }}
+        coll = fs.collection('top_collection').document('top_document')
+        nested_collections = coll.collections()
+        self.assertEqual(2, len(coll.collections()))
+        self.assertEqual('nested_collection1', nested_collections[0].id)
+        self.assertEqual('nested_collection2', nested_collections[1].id)


### PR DESCRIPTION
Adding 2 updates and a test
- property id in CollectionReference. This is now supported in firestore
- method collection() in DocumentReference. You can now get a list of subcollections within a document. 