### PR TITLE
Add path property

### DIFF
--- a/mockfirestore/document.py
+++ b/mockfirestore/document.py
@@ -63,6 +63,10 @@ class DocumentReference:
     def id(self):
         return self._path[-1]
 
+    @property
+    def path(self):
+        return '/'.join(self._path)
+
     def get(self) -> DocumentSnapshot:
         return DocumentSnapshot(self, get_by_path(self._data, self._path))
 

--- a/tests/test_document_reference.py
+++ b/tests/test_document_reference.py
@@ -16,6 +16,14 @@ class TestDocumentReference(TestCase):
         self.assertEqual({'id': 1}, doc.to_dict())
         self.assertEqual('first', doc.id)
 
+    def test_document_path_property(self):
+        fs = MockFirestore()
+        fs._data = {'foo': {
+            'first': {'id': 1}
+        }}
+        doc = fs.document('foo/first')
+        self.assertEqual('foo/first', doc.path)
+
     def test_set_document_by_path(self):
         fs = MockFirestore()
         fs._data = {}
@@ -23,7 +31,7 @@ class TestDocumentReference(TestCase):
         fs.document('foo/doc1/bar/doc2').set(doc_content)
         doc = fs.document('foo/doc1/bar/doc2').get().to_dict()
         self.assertEqual(doc_content, doc)
-        
+
     def test_document_get_returnsDocument(self):
         fs = MockFirestore()
         fs._data = {'foo': {


### PR DESCRIPTION
Actual firestore client has a `path` property, documented [here](https://cloud.google.com/python/docs/reference/firestore/latest/document)

This is used in e.g. [fireo](https://cloud.google.com/python/docs/reference/firestore/latest/document)