### PR TITLE
Add list collections to doc ref

### DIFF
--- a/mockfirestore/collection.py
+++ b/mockfirestore/collection.py
@@ -14,6 +14,10 @@ class CollectionReference:
         self._path = path
         self.parent = parent
 
+    @property
+    def id(self):
+        return self._path[-1]
+
     def document(self, document_id: Optional[str] = None) -> DocumentReference:
         collection = get_by_path(self._data, self._path)
         if document_id is None:

--- a/mockfirestore/document.py
+++ b/mockfirestore/document.py
@@ -67,7 +67,7 @@ class DocumentReference:
     def path(self):
         return '/'.join(self._path)
 
-    def get(self) -> DocumentSnapshot:
+    def get(self, **kwargs) -> DocumentSnapshot:
         return DocumentSnapshot(self, get_by_path(self._data, self._path))
 
     def delete(self):

--- a/mockfirestore/document.py
+++ b/mockfirestore/document.py
@@ -63,6 +63,10 @@ class DocumentReference:
     def id(self):
         return self._path[-1]
 
+    @property
+    def path(self):
+        return '/'.join(self._path)
+
     def get(self) -> DocumentSnapshot:
         return DocumentSnapshot(self, get_by_path(self._data, self._path))
 

--- a/mockfirestore/document.py
+++ b/mockfirestore/document.py
@@ -96,3 +96,13 @@ class DocumentReference:
         if name not in document:
             set_by_path(self._data, new_path, {})
         return CollectionReference(self._data, new_path, parent=self)
+
+    def collections(self) -> list['CollectionReference']:
+        from mockfirestore.collection import CollectionReference
+        document = get_by_path(self._data, self._path)
+        _collections = []
+        for collname, values in document.items():
+            if isinstance(values, dict):
+                new_path = self._path + [collname]
+                _collections.append(CollectionReference(self._data, new_path, parent=self))
+        return _collections

--- a/tests/test_document_reference.py
+++ b/tests/test_document_reference.py
@@ -89,6 +89,23 @@ class TestDocumentReference(TestCase):
 
         self.assertEqual({'id': 1.1}, doc)
 
+    def test_get_nestedCollections(self):
+        fs = MockFirestore()
+        fs._data = {'top_collection': {
+            'top_document': {
+                'id': 1,
+                'nested_collection': {
+                    'nested_document': {'id': 1.1}
+                }
+            }
+        }}
+        collections = fs.collection('top_collection')\
+            .document('top_document')\
+            .collections()
+
+        self.assertEqual(1, len(collections))
+        self.assertEqual(collections[0].id, 'nested_collection')
+
     def test_get_nestedDocument_documentDoesNotExist(self):
         fs = MockFirestore()
         fs._data = {'top_collection': {

--- a/tests/test_document_reference.py
+++ b/tests/test_document_reference.py
@@ -16,6 +16,15 @@ class TestDocumentReference(TestCase):
         self.assertEqual({'id': 1}, doc.to_dict())
         self.assertEqual('first', doc.id)
 
+    def test_get_document_by_path_with_transaction_kwarg(self):
+        fs = MockFirestore()
+        fs._data = {'foo': {
+            'first': {'id': 1}
+        }}
+        doc = fs.document('foo/first').get(transaction='tx')
+        self.assertEqual({'id': 1}, doc.to_dict())
+        self.assertEqual('first', doc.id)
+
     def test_document_path_property(self):
         fs = MockFirestore()
         fs._data = {'foo': {

--- a/tests/test_document_reference.py
+++ b/tests/test_document_reference.py
@@ -16,6 +16,14 @@ class TestDocumentReference(TestCase):
         self.assertEqual({'id': 1}, doc.to_dict())
         self.assertEqual('first', doc.id)
 
+    def test_document_path_property(self):
+        fs = MockFirestore()
+        fs._data = {'foo': {
+            'first': {'id': 1}
+        }}
+        doc = fs.document('foo/first')
+        self.assertEqual('foo/first', doc.path)
+
     def test_set_document_by_path(self):
         fs = MockFirestore()
         fs._data = {}
@@ -23,7 +31,7 @@ class TestDocumentReference(TestCase):
         fs.document('foo/doc1/bar/doc2').set(doc_content)
         doc = fs.document('foo/doc1/bar/doc2').get().to_dict()
         self.assertEqual(doc_content, doc)
-        
+
     def test_document_get_returnsDocument(self):
         fs = MockFirestore()
         fs._data = {'foo': {


### PR DESCRIPTION
build on #79 

Adds a `.collections()` method and `id()` property to DocumentReference and CollectionReference respectively. Used by fireo [here](https://github.com/octabytes/FireO/blob/master/src/fireo/models/model.py#L463)