### PR TITLE
Add support for optional arguments in DocumentReference.get

### DIFF
--- a/mockfirestore/document.py
+++ b/mockfirestore/document.py
@@ -1,7 +1,7 @@
 from copy import deepcopy
 from functools import reduce
 import operator
-from typing import List, Dict, Any
+from typing import List, Dict, Any, Optional, Iterable
 from mockfirestore import NotFound
 from mockfirestore._helpers import (
     Timestamp, Document, Store, get_by_path, set_by_path, delete_by_path
@@ -63,7 +63,13 @@ class DocumentReference:
     def id(self):
         return self._path[-1]
 
-    def get(self) -> DocumentSnapshot:
+    def get(
+        self,
+        field_paths: Optional[Iterable[str]] = None,
+        transaction: Any = None,
+        retry: Any = None,
+        timeout: Optional[float] = None,
+    ) -> DocumentSnapshot:
         return DocumentSnapshot(self, get_by_path(self._data, self._path))
 
     def delete(self):


### PR DESCRIPTION
Solves #86.

Purposely does nothing with the optional arguments because the main value of supporting them is that tests will not fail with `TypeError: DocumentReference.get() takes 1 positional argument but X were given`.